### PR TITLE
json: fix pb_message_to_json to return NULL for NULL input

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,7 +311,6 @@ TODO: Multi-Valued Index on Protobuf Fields
 - [ ] Add `pb_{message,wire_json}_search_repeated_message_field_by_{type}_key(message, field_number, key_field_number, key, default_value)` function (finds the first one)
 - [ ] JSON to Protobuf Conversion
 - [x] Protobuf to JSON Conversion
-  - [ ] Fix NULL conversion bug
   - [ ] **[Editions](https://protobuf.dev/editions/overview/) Support**
 
 ## Limitations

--- a/protobuf-json.sql
+++ b/protobuf-json.sql
@@ -237,6 +237,11 @@ proc: BEGIN
 
 	SET @@SESSION.max_sp_recursion_depth = 255;
 
+	IF buf IS NULL THEN
+		SET result = NULL;
+		LEAVE proc;
+	END IF;
+
 	IF full_type_name LIKE '.google.protobuf.%' THEN
 		SET result = _pb_wire_json_decode_wkt_as_json(pb_message_to_wire_json(buf), full_type_name);
 		IF result IS NOT NULL THEN

--- a/tests/pb_message_to_json_test.go
+++ b/tests/pb_message_to_json_test.go
@@ -617,3 +617,24 @@ func TestMessageToJsonWkt(t *testing.T) {
 		testMessageToJson(t, "google.protobuf.FieldMask field_mask_field = 1;", `{"fieldMaskField": "path1,path2"}`)
 	})
 }
+
+func TestMessageToJsonNullInput(t *testing.T) {
+	p := testutils.NewProtoTestSupport(t, map[string]string{
+		"main.proto": `
+			syntax = "proto3";
+			message Test {
+				int32 value = 1;
+			}
+		`,
+	})
+
+	descriptorSetName := "a"
+	typeName := ".Test"
+
+	AssertThatCall(t, "pb_descriptor_set_load(?, ?)", descriptorSetName, p.GetSerializedFileDescriptorSet()).ShouldSucceed()
+	defer func() {
+		AssertThatCall(t, "pb_descriptor_set_delete(?)", descriptorSetName).ShouldSucceed()
+	}()
+
+	RunTestThatExpression(t, "pb_message_to_json(?, ?, ?)", descriptorSetName, typeName, nil).IsNull()
+}


### PR DESCRIPTION
Add NULL check in _pb_message_to_json procedure to return NULL when the input buffer is NULL, matching expected SQL NULL handling behavior. Includes test case to verify the fix.